### PR TITLE
Convert claim tests to subtests

### DIFF
--- a/claim_test.go
+++ b/claim_test.go
@@ -37,15 +37,18 @@ func TestCheckIfClaimContainsAllClaimContainsCheck(t *testing.T) {
 			},
 			claimContainsCheck: []string{"name=John", "tags=admin"},
 			expectedResult:     false,
-			description:        "Case 2: Expected to return false",
+			description:        "Case 3: Expected to return false",
 		},
 	}
 
 	for _, tc := range testCases {
-		result := checkIfClaimContainsAllClaimContainsCheck(tc.claims, tc.claimContainsCheck)
-		if result != tc.expectedResult {
-			t.Errorf("%s: checkIfClaimContainsAllClaimContainsCheck() = %v;"+
-				"want %v", tc.description, result, tc.expectedResult)
-		}
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			result := checkIfClaimContainsAllClaimContainsCheck(tc.claims, tc.claimContainsCheck)
+			if result != tc.expectedResult {
+				t.Errorf("%s: checkIfClaimContainsAllClaimContainsCheck() = %v;"+
+					"want %v", tc.description, result, tc.expectedResult)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- change third table test description to reflect case number
- convert test loop in `TestCheckIfClaimContainsAllClaimContainsCheck` to subtests

## Testing
- `go test ./...` *(fails: github dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687eb5b691b8832892b70b669818042f